### PR TITLE
Fix assertion triggered when running Poisson on Linux

### DIFF
--- a/AddNoise/poisson.h
+++ b/AddNoise/poisson.h
@@ -15,12 +15,12 @@ void poisson_apply(const void *_srcp, void *_dstp,
     for (auto x{0}; x < width; x++) {
       if (srcp[x] == 0) {
         dstp[x] = 0;
-      } else {
-        auto val = srcp[x] / scale;
-        std::poisson_distribution<int> distribution(val);
-        dstp[x] = static_cast<pixel_t>(
-            std::clamp((int)(distribution(generator) * scale), 0, peak));
+        continue;
       }
+      auto val = srcp[x] / scale;
+      std::poisson_distribution<int> distribution(val);
+      dstp[x] = static_cast<pixel_t>(
+          std::clamp((int)(distribution(generator) * scale), 0, peak));
     }
 
     srcp += stride;

--- a/AddNoise/poisson.h
+++ b/AddNoise/poisson.h
@@ -13,10 +13,14 @@ void poisson_apply(const void *_srcp, void *_dstp,
 
   for (auto y{0}; y < height; y++) {
     for (auto x{0}; x < width; x++) {
-      auto val = srcp[x] / scale;
-      std::poisson_distribution<int> distribution(val);
-      dstp[x] = static_cast<pixel_t>(
-          std::clamp((int)(distribution(generator) * scale), 0, peak));
+      if (srcp[x] == 0) {
+        dstp[x] = 0;
+      } else {
+        auto val = srcp[x] / scale;
+        std::poisson_distribution<int> distribution(val);
+        dstp[x] = static_cast<pixel_t>(
+            std::clamp((int)(distribution(generator) * scale), 0, peak));
+      }
     }
 
     srcp += stride;


### PR DESCRIPTION
On Linux it is currently possible to trigger an assertion, "std::poisson_distribution<_IntType>::param_type::param_type(double) [with _IntType = int]: Assertion '_M_mean > 0.0' failed", when using the Poisson grainer. This seems to occur when the src pixel's value is 0. This change avoids the assertion by not running the distribution function when the src pixel is 0.